### PR TITLE
fix(weather): treat 0°C as valid temperature in chart

### DIFF
--- a/src/lib/components/weather/WeatherForecast.svelte
+++ b/src/lib/components/weather/WeatherForecast.svelte
@@ -49,7 +49,8 @@ function getTemperatureChartPath(periods: ForecastPeriod[]): {
   if (periods.length === 0)
     return { path: '', points: [], minTemp: 0, maxTemp: 0 };
 
-  const temps = periods.map((p) => p.temperature).filter((t) => t !== 0);
+  // Filter out null/undefined temps, but keep 0 (0°C is valid!)
+  const temps = periods.map((p) => p.temperature).filter((t) => t != null);
   if (temps.length === 0)
     return { path: '', points: [], minTemp: 0, maxTemp: 0 };
 
@@ -80,9 +81,11 @@ function getTemperatureChartPath(periods: ForecastPeriod[]): {
       label = period.name.replace(' for Bentley', '').split(' ')[0];
     }
 
+    // Only use fallback position for truly missing data (null/undefined)
+    const hasValidTemp = period.temperature != null;
     return {
       x,
-      y: period.temperature === 0 ? height / 2 : y,
+      y: hasValidTemp ? y : height / 2,
       temp: period.temperature,
       label,
     };
@@ -204,7 +207,7 @@ function getTemperatureChartPath(periods: ForecastPeriod[]): {
                         fill="var(--color-primary, #2563eb)"
                       />
                       <!-- Temperature labels -->
-                      {#if point.temp !== 0}
+                      {#if point.temp != null}
                         <text
                           x={point.x}
                           y={point.y - 8}


### PR DESCRIPTION
## Summary
- Fixed temperature chart treating 0°C as missing data
- Changed from `!== 0` to `!= null` checks to properly distinguish valid zero temperatures from missing data
- Fixes winter weather display where 0°C readings were plotted at vertical center instead of correct position

## Test plan
- [ ] View weather forecast with 0°C temperatures
- [ ] Verify chart plots 0°C at correct y-axis position based on min/max range
- [ ] Verify temperature label shows "0°" instead of being hidden