### PR TITLE
feat(components): add analytics callback props to TownHeader, Calendar, DayView

### DIFF
--- a/src/lib/components/calendar/Calendar.svelte
+++ b/src/lib/components/calendar/Calendar.svelte
@@ -11,6 +11,16 @@ interface Props {
   year?: number;
   month?: number; // 0-indexed (0 = January)
   baseUrl?: string;
+  /** Callback when navigating to prev/next month */
+  onMonthNavigate?: (
+    direction: 'prev' | 'next',
+    year: number,
+    month: number,
+  ) => void;
+  /** Callback when a date cell is clicked */
+  onDateSelect?: (date: string, hasEvents: boolean) => void;
+  /** Callback when Today button is clicked */
+  onTodayClick?: () => void;
 }
 
 const {
@@ -18,6 +28,9 @@ const {
   year: initialYear = new Date().getFullYear(),
   month: initialMonth = new Date().getMonth(),
   baseUrl = '/events',
+  onMonthNavigate,
+  onDateSelect,
+  onTodayClick,
 }: Props = $props();
 
 let currentYear = $state(initialYear);
@@ -134,6 +147,7 @@ function prevMonth() {
   } else {
     currentMonth--;
   }
+  onMonthNavigate?.('prev', currentYear, currentMonth);
 }
 
 function nextMonth() {
@@ -143,12 +157,14 @@ function nextMonth() {
   } else {
     currentMonth++;
   }
+  onMonthNavigate?.('next', currentYear, currentMonth);
 }
 
 function goToToday() {
   const today = new Date();
   currentYear = today.getFullYear();
   currentMonth = today.getMonth();
+  onTodayClick?.();
 }
 
 // Generate day URL
@@ -218,12 +234,14 @@ const yearOptions = $derived(() => {
       {#each calendarDays() as { day, month, year, isCurrentMonth, isToday }}
         {@const dayEvents = getEventsForDate(year, month, day)}
         {@const hasEvents = dayEvents.length > 0}
+        {@const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`}
         <a
           href={getDayUrl(year, month, day)}
           class="day-cell"
           class:other-month={!isCurrentMonth}
           class:today={isToday}
           class:has-events={hasEvents}
+          onclick={() => onDateSelect?.(dateStr, hasEvents)}
         >
           <span class="day-number">{day}</span>
           {#if hasEvents}

--- a/src/lib/components/calendar/DayView.svelte
+++ b/src/lib/components/calendar/DayView.svelte
@@ -11,6 +11,8 @@ interface Props {
   events?: DayEventDetail[] | null;
   forecast?: DayForecast | null;
   calendarUrl?: string;
+  /** Callback when an event card is clicked */
+  onEventClick?: (eventType: string, eventName: string) => void;
 }
 
 const {
@@ -18,6 +20,7 @@ const {
   events = null,
   forecast = null,
   calendarUrl = '/events',
+  onEventClick,
 }: Props = $props();
 
 // Format full date
@@ -125,7 +128,7 @@ function getTypeLabel(type: string): string {
             {#each typeEvents as event}
               {@const url = getEventUrl(event)}
               {#if url}
-                <a href={url} class="event-card event-card--link">
+                <a href={url} class="event-card event-card--link" onclick={() => onEventClick?.(event.type, event.name)}>
                   <div class="event-time">{event.startTime}</div>
                   <div class="event-details">
                     <span class="event-name">{event.name}</span>
@@ -136,7 +139,7 @@ function getTypeLabel(type: string): string {
                   <span class="event-arrow">→</span>
                 </a>
               {:else}
-                <div class="event-card">
+                <div class="event-card" onclick={() => onEventClick?.(event.type, event.name)}>
                   <div class="event-time">{event.startTime}</div>
                   <div class="event-details">
                     <span class="event-name">{event.name}</span>


### PR DESCRIPTION
## Summary
- Add optional callback props to TownHeader, Calendar, and DayView components for analytics tracking

## Callback Props Added

### TownHeader
| Prop | Signature | Description |
|------|-----------|-------------|
| `onDaySelect` | `(dayIndex: number, dayName: string) => void` | Fired when a day tab is selected |
| `onViewToggle` | `(viewType: 'graph' \| 'hourly') => void` | Fired when graph/hourly toggle is clicked |
| `onCollapse` | `(dayIndex: number) => void` | Fired when panel is collapsed |

### Calendar
| Prop | Signature | Description |
|------|-----------|-------------|
| `onMonthNavigate` | `(direction: 'prev' \| 'next', year: number, month: number) => void` | Fired when navigating months |
| `onDateSelect` | `(date: string, hasEvents: boolean) => void` | Fired when a day cell is clicked |
| `onTodayClick` | `() => void` | Fired when Today button is clicked |

### DayView
| Prop | Signature | Description |
|------|-----------|-------------|
| `onEventClick` | `(eventType: string, eventName: string) => void` | Fired when an event card is clicked |

## Usage Example
```svelte
<TownHeader
  forecast={weather}
  onDaySelect={(idx, name) => analytics.weather.daySelect(idx, name)}
  onViewToggle={(view) => analytics.weather.viewToggle(view)}
  onCollapse={(idx) => analytics.weather.panelCollapse(idx)}
/>

<Calendar
  events={events}
  onMonthNavigate={(dir, y, m) => analytics.calendar.monthNavigate(dir, y, m)}
  onDateSelect={(date, hasEvents) => analytics.calendar.dateSelect(date, hasEvents)}
  onTodayClick={() => analytics.calendar.todayClick()}
/>
```

## Test plan
- [ ] Verify TownHeader callbacks fire on day selection, view toggle, and collapse
- [ ] Verify Calendar callbacks fire on month navigation, date selection, and today click
- [ ] Verify DayView callbacks fire on event card clicks
- [ ] Ensure no breaking changes to existing usage