### PR TITLE
fix(weather): remove mock data fallback, hide widget when no forecast

### DIFF
--- a/src/lib/components/town/TownHeader.svelte
+++ b/src/lib/components/town/TownHeader.svelte
@@ -99,7 +99,7 @@ const dayForecasts: DayForecast[] = $derived(
           hourlyData: transformHourlyData(day.periods, index),
         };
       })
-    : getMockData(),
+    : [],
 );
 
 function getDateFromOffset(offset: number): Date {
@@ -776,6 +776,7 @@ $effect(() => {
 });
 </script>
 
+{#if dayForecasts.length > 0}
 <div class="weather-widget">
   <div
     class="tabs-wrapper"
@@ -1023,6 +1024,7 @@ $effect(() => {
     </div>
   {/if}
 </div>
+{/if}
 
 <style>
   .weather-widget {

--- a/src/lib/components/weather/WeatherHeader.svelte
+++ b/src/lib/components/weather/WeatherHeader.svelte
@@ -47,7 +47,7 @@ const dayForecasts: DayForecast[] = $derived(
           hourlyData: transformHourlyData(day.periods, index),
         };
       })
-    : getMockData(),
+    : [],
 );
 
 function getDateFromOffset(offset: number): Date {
@@ -265,6 +265,7 @@ function handleTabsKeyDown(e: KeyboardEvent) {
 }
 </script>
 
+{#if dayForecasts.length > 0}
 <div class="weather-widget">
   <div
     class="tabs-wrapper"
@@ -337,6 +338,7 @@ function handleTabsKeyDown(e: KeyboardEvent) {
     </div>
   {/if}
 </div>
+{/if}
 
 <style>
   .weather-widget {


### PR DESCRIPTION
## Summary
- Remove fake/mock weather data fallback that showed random 15-25°C temperatures when no forecast data was available
- Weather components now hide completely when no forecast data exists instead of showing misleading fake data

## Changes
- `TownHeader.svelte`: Return empty array instead of `getMockData()`, wrap in conditional render
- `WeatherHeader.svelte`: Return empty array instead of `getMockData()`, wrap in conditional render

## Test plan
- [ ] Verify weather widget shows real data when forecast is available
- [ ] Verify weather widget is hidden when no forecast data exists
- [ ] Check both TownHeader and WeatherHeader components